### PR TITLE
Support resolving source module from Herd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ modules
 /eclipse
 /test-result
 /*.ids
+/classes/
+/.DS_Store
+/.java-version
+/server.pid

--- a/app/models/HerdDependency.java
+++ b/app/models/HerdDependency.java
@@ -1,0 +1,24 @@
+package models;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import play.db.jpa.Model;
+
+// TODO:  Figure out what needs to go in here, exactly
+@Entity
+@SuppressWarnings("serial")
+public class HerdDependency extends Model {
+
+    public String name;
+	public String version;
+
+	@ManyToOne
+	public Upload upload;
+
+    public HerdDependency(String name, String version, Upload upload) {
+        this.name = name;
+        this.version = version;
+        this.upload = upload;
+    }
+}

--- a/app/models/HerdMetainf.java
+++ b/app/models/HerdMetainf.java
@@ -21,7 +21,7 @@ public class HerdMetainf extends GenericModel {
 
     // IMPORTANT This number must be the same as the one found in
     // the latest `db/db-XX.sql` and `db/update-XX.sql` files !!!
-    public static final int DB_SCHEMA_VERSION = 19;
+    public static final int DB_SCHEMA_VERSION = 20;
     
     public static final String KEY_DB_SCHEMA_VERSION = "db_schema_version";
     

--- a/app/models/Upload.java
+++ b/app/models/Upload.java
@@ -24,6 +24,9 @@ public class Upload extends Model {
     @OneToMany(mappedBy = "upload", cascade = CascadeType.REMOVE)
     public List<MavenDependency> mavenDependencies = new ArrayList<MavenDependency>();
 
+    @OneToMany(mappedBy = "upload", cascade = CascadeType.REMOVE)
+    public List<HerdDependency> herdDependencies = new ArrayList<HerdDependency>();
+
 	
 	@Transient
 	public long getSize(){
@@ -46,6 +49,14 @@ public class Upload extends Model {
         for(MavenDependency md : mavenDependencies){
             if(md.name.equals(name) && md.version.equals(version))
                 return md;
+        }
+        return null;
+    }
+
+    public HerdDependency findHerdDependency(String name, String version) {
+        for(HerdDependency hd : herdDependencies){
+            if(hd.name.equals(name) && hd.version.equals(version))
+                return hd;
         }
         return null;
     }

--- a/app/util/ModuleChecker.java
+++ b/app/util/ModuleChecker.java
@@ -1098,7 +1098,6 @@ public class ModuleChecker {
         // try to find it in the repo
         models.ModuleVersion dep = models.ModuleVersion.findByVersion(name, version);
         if(dep == null){
-            Logger.info("dep is null");
             if(optional){
                 m.diagnostics.add(new Diagnostic("warning", lead+" was not found but is optional"));
                 dependencies.add(new Import(name, version, optional, export));
@@ -1124,7 +1123,6 @@ public class ModuleChecker {
                     diagnostic.dependencyVersion = version;
                     m.diagnostics.add(diagnostic);
                 }else if (CeylonRuntime.jvm == ceylonRuntime && upload.findMavenDependency(name, version) != null){
-                    Logger.info("else if maven not null");
                     dependencies.add(new Import(name, version, optional, export, upload.findMavenDependency(name, version)));
                     Diagnostic diagnostic = new Diagnostic("success", lead+" resolved from Maven Central");
                     diagnostic.dependencyResolvedFromMaven = true;

--- a/app/views/Uploads/view.html
+++ b/app/views/Uploads/view.html
@@ -296,11 +296,30 @@ $ <span class="xml-tag">ceylon plugin pack</span> <span class="xml-attr">--out</
                                             title="Generate a new checksum for this file"><i class="icon-plus"></i> Generate Checksum</button>
                                     #{/form}
                                 #{/elseif}
-                                #{elseif diagnostic.dependencyNotFound}
+                                #{elseif diagnostic.dependencyNotFoundFromHerdAndMaven}
+                                    &nbsp;
+                                    #{form @Uploads.resolveHerdDependency(upload.id, diagnostic.dependencyName, diagnostic.dependencyVersion), class:"form-no-margin inline"}
+                                        <button type="submit" class="btn btn-mini"
+                                            title="Resolve dependency in Herd"><i class="icon-eye-open"></i> Resolve from Herd</button>
+                                    #{/form}
                                     &nbsp;
                                     #{form @Uploads.resolveMavenDependency(upload.id, diagnostic.dependencyName, diagnostic.dependencyVersion), class:"form-no-margin inline"}
                                         <button type="submit" class="btn btn-mini"
-                                            title="Resolve dependency in Maven Central"><i class="icon-eye-open"></i> Resolve from Maven Central</button>
+                                            title="Resolve dependency in Herd"><i class="icon-eye-open"></i> Resolve from Maven Central</button>
+                                    #{/form}
+                                #{/elseif}
+                                #{elseif diagnostic.dependencyNotFoundFromHerdOnly}
+                                    &nbsp;
+                                    #{form @Uploads.resolveHerdDependency(upload.id, diagnostic.dependencyName, diagnostic.dependencyVersion), class:"form-no-margin inline"}
+                                        <button type="submit" class="btn btn-mini"
+                                            title="Resolve dependency in Herd"><i class="icon-eye-open"></i> Resolve from Herd</button>
+                                    #{/form}
+                                #{/elseif}
+                                #{elseif diagnostic.dependencyResolvedFromHerd}
+                                    &nbsp;
+                                    #{form @Uploads.removeHerdDependency(upload.id, diagnostic.dependencyName, diagnostic.dependencyVersion), class:"form-no-margin inline"}
+                                        <button type="submit" class="btn btn-mini"
+                                            title="Do not resolve dependency from Herd"><i class="icon-remove-sign"></i> Do not resolve from Herd</button>
                                     #{/form}
                                 #{/elseif}
                                 #{elseif diagnostic.dependencyResolvedFromMaven}

--- a/conf/routes
+++ b/conf/routes
@@ -78,8 +78,11 @@ POST    /uploads/{id}/delete-file                          UploadAPI.deleteFile
 POST    /uploads/{id}/delete-file-async                    UploadAPI.deleteFileAsync
 POST    /uploads/{id}/add-checksum                         UploadAPI.addChecksum
 POST    /uploads/{id}/resolve-from-maven                   Uploads.resolveMavenDependency
-POST    /uploads/{id}/resolve-from-herd                    Uploads.removeMavenDependency
+POST    /uploads/{id}/resolve-from-herd                    Uploads.resolveHerdDependency
+POST    /uploads/{id}/remove-from-maven                    Uploads.removeMavenDependency
+POST    /uploads/{id}/remove-from-herd                     Uploads.removeHerdDependency
 POST    /uploads/{id}/clear-maven-dependencies             Uploads.clearMavenDependencies
+POST    /uploads/{id}/clear-herd-dependencies              Uploads.clearMavenDependencies
                                                            
 GET     /uploads/{id}/repo/{<.*>path}                      UploadAPI.viewFile
 PUT     /uploads/{id}/repo/{<.*>path}                      UploadAPI.addFile

--- a/db/db-20.sql
+++ b/db/db-20.sql
@@ -1,0 +1,380 @@
+    -- DON'T FORGET TO UPDATE THIS EACH TIME THE DB SCHEMA IS CHANGED!!
+    -- It should have the same number as the "db-XX.sql" file used to create the DB
+    -- Also, don't forget that the "update-XX.sql" needs to update the version
+    -- number in the database and that the number must also be updated in the code
+    -- in file "app/models/HerdMetainf.java"
+    \set DB_SCHEMA_VERSION '\'20\''
+
+    alter table Comment 
+        drop constraint FK9BDE863F856AF776;
+
+    alter table Comment 
+        drop constraint FK9BDE863FB2FABF16;
+
+    alter table Dependency 
+        drop constraint FK7540AF6B7BF02576;
+
+    alter table MavenDependency 
+        drop constraint FK50917167C8A23E;
+
+    alter table Module 
+        drop constraint FK89B0928CFA266C1E;
+
+    alter table Module 
+        drop constraint FK89B0928CB2FABF16;
+
+    alter table ModuleComment 
+        drop constraint FK6EA3E3353B2465E;
+
+    alter table ModuleComment 
+        drop constraint FK6EA3E33B2FABF16;
+
+    alter table ModuleMember 
+        drop constraint FK4A8AF0467BF02576;
+
+    alter table ModuleRating 
+        drop constraint FK52DE174953B2465E;
+
+    alter table ModuleRating 
+        drop constraint FK52DE1749B2FABF16;
+
+    alter table ModuleScript 
+        drop constraint FK54AE36777BF02576;
+
+    alter table ModuleVersion 
+        drop constraint FKE3396CAC53B2465E;
+
+    alter table ModuleVersion_Author 
+        drop constraint FK9BE1449E7BF02576;
+
+    alter table ModuleVersion_Author 
+        drop constraint FK9BE1449E42A7BA21;
+
+    alter table Project 
+        drop constraint FK50C8E2F9B2FABF16;
+
+    alter table Upload 
+        drop constraint FK9768FA21B2FABF16;
+
+    alter table module_admin_user 
+        drop constraint FK8CE50E6E555F243E;
+
+    alter table module_admin_user 
+        drop constraint FK8CE50E6E7080C8FC;
+
+    drop table Author cascade;
+
+    drop table Category cascade;
+
+    drop table Comment cascade;
+
+    drop table Dependency cascade;
+
+    drop table MavenDependency cascade;
+
+    drop table Module cascade;
+
+    drop table ModuleComment cascade;
+
+    drop table ModuleMember cascade;
+
+    drop table ModuleRating cascade;
+
+    drop table ModuleScript cascade;
+
+    drop table ModuleVersion cascade;
+
+    drop table ModuleVersion_Author cascade;
+
+    drop table Project cascade;
+
+    drop table Upload cascade;
+
+    drop table module_admin_user cascade;
+
+    drop table user_table cascade;
+
+    drop table herd_metainf cascade;
+
+    drop sequence hibernate_sequence;
+
+    create table Author (
+        id int8 not null,
+        name TEXT,
+        primary key (id)
+    );
+
+    create table Category (
+        id int8 not null,
+        description TEXT,
+        name varchar(255) not null unique,
+        primary key (id)
+    );
+
+    create table Comment (
+        id int8 not null,
+        date timestamp,
+        status varchar(255),
+        text TEXT,
+        owner_id int8,
+        project_id int8,
+        primary key (id)
+    );
+
+    create table Dependency (
+        id int8 not null,
+        export bool not null,
+        name varchar(255),
+        optional bool not null,
+        resolvedFromMaven bool not null,
+        version varchar(255),
+        moduleVersion_id int8,
+        primary key (id)
+    );
+
+    create table HerdDependency (
+        id int8 not null,
+        name varchar(255),
+        version varchar(255),
+        upload_id int8,
+        primary key (id)
+    );
+
+    create table MavenDependency (
+        id int8 not null,
+        name varchar(255),
+        version varchar(255),
+        upload_id int8,
+        primary key (id)
+    );
+
+    create table Module (
+        id int8 not null,
+        codeURL varchar(255),
+        friendlyName varchar(255),
+        homeURL varchar(255),
+        issueTrackerURL varchar(255),
+        name varchar(255) not null unique,
+        category_id int8,
+        owner_id int8 not null,
+        primary key (id)
+    );
+
+    create table ModuleComment (
+        id int8 not null,
+        date timestamp,
+        text TEXT,
+        module_id int8,
+        owner_id int8,
+        primary key (id)
+    );
+
+    create table ModuleMember (
+        id int8 not null,
+        name varchar(255),
+        packageName varchar(255),
+        type varchar(255),
+        moduleVersion_id int8,
+        primary key (id)
+    );
+
+    create table ModuleRating (
+        id int8 not null,
+        mark int4 not null,
+        module_id int8,
+        owner_id int8,
+        primary key (id)
+    );
+
+    create table ModuleScript (
+        id int8 not null,
+        description varchar(255),
+        name varchar(255),
+        unix bool not null,
+        moduleVersion_id int8,
+        plugin bool not null,
+        module varchar(255),
+        primary key (id)
+    );
+
+    create table ModuleVersion (
+        id int8 not null,
+        changelog TEXT,
+        doc TEXT,
+        downloads int8 not null,
+        isAPIPresent bool not null,
+        isCarPresent bool not null,
+        isDocPresent bool not null,
+        isJarPresent bool not null,
+        isJsPresent bool not null,
+        isResourcesPresent bool not null,
+        isRunnable bool not null,
+        isScriptsPresent bool not null,
+        isSourcePresent bool not null,
+        jsBinMajor int4 not null,
+        jsBinMinor int4 not null,
+        jsdownloads int8 not null,
+        jvmBinMajor int4 not null,
+        jvmBinMinor int4 not null,
+        license TEXT,
+        published timestamp not null,
+        sourceDownloads int8 not null,
+        version varchar(255) not null,
+        module_id int8 not null,
+        primary key (id),
+        unique (module_id, version)
+    );
+
+    create table ModuleVersion_Author (
+        ModuleVersion_id int8 not null,
+        authors_id int8 not null
+    );
+
+    create table Project (
+        id int8 not null,
+        description TEXT,
+        license varchar(255),
+        moduleName varchar(255) not null,
+        motivation TEXT,
+        role varchar(255),
+        status varchar(255),
+        url varchar(255),
+        owner_id int8 not null,
+        primary key (id)
+    );
+
+    create table Upload (
+        id int8 not null,
+        created timestamp,
+        owner_id int8,
+        primary key (id)
+    );
+
+    create table module_admin_user (
+        module int8 not null,
+        admin int8 not null
+    );
+
+    create table user_table (
+        id int8 not null,
+        confirmationCode varchar(255) unique,
+        email varchar(255) not null,
+        firstName varchar(255),
+        admin bool,
+        isBCrypt bool not null,
+        lastName varchar(255),
+        password varchar(255),
+        passwordResetConfirmationCode varchar(255) unique,
+        passwordResetConfirmationDate timestamp,
+        salt varchar(255),
+        status varchar(255) not null,
+        userName varchar(255) unique,
+        primary key (id)
+    );
+
+    create table herd_metainf (
+        id int8 not null,
+        key varchar(255) not null unique,
+        value varchar(255),
+        primary key (id)
+    );
+
+    insert into herd_metainf (id, key, value)
+    values (1, 'db_schema_version', :DB_SCHEMA_VERSION);
+
+    alter table Comment 
+        add constraint FK9BDE863F856AF776 
+        foreign key (project_id) 
+        references Project;
+
+    alter table Comment 
+        add constraint FK9BDE863FB2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table Dependency 
+        add constraint FK7540AF6B7BF02576 
+        foreign key (moduleVersion_id) 
+        references ModuleVersion;
+
+    alter table MavenDependency 
+        add constraint FK50917167C8A23E 
+        foreign key (upload_id) 
+        references Upload;
+
+    alter table Module 
+        add constraint FK89B0928CFA266C1E 
+        foreign key (category_id) 
+        references Category;
+
+    alter table Module 
+        add constraint FK89B0928CB2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table ModuleComment 
+        add constraint FK6EA3E3353B2465E 
+        foreign key (module_id) 
+        references Module;
+
+    alter table ModuleComment 
+        add constraint FK6EA3E33B2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table ModuleMember 
+        add constraint FK4A8AF0467BF02576 
+        foreign key (moduleVersion_id) 
+        references ModuleVersion;
+
+    alter table ModuleRating 
+        add constraint FK52DE174953B2465E 
+        foreign key (module_id) 
+        references Module;
+
+    alter table ModuleRating 
+        add constraint FK52DE1749B2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table ModuleScript 
+        add constraint FK54AE36777BF02576 
+        foreign key (moduleVersion_id) 
+        references ModuleVersion;
+
+    alter table ModuleVersion 
+        add constraint FKE3396CAC53B2465E 
+        foreign key (module_id) 
+        references Module;
+
+    alter table ModuleVersion_Author 
+        add constraint FK9BE1449E7BF02576 
+        foreign key (ModuleVersion_id) 
+        references ModuleVersion;
+
+    alter table ModuleVersion_Author 
+        add constraint FK9BE1449E42A7BA21 
+        foreign key (authors_id) 
+        references Author;
+
+    alter table Project 
+        add constraint FK50C8E2F9B2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table Upload 
+        add constraint FK9768FA21B2FABF16 
+        foreign key (owner_id) 
+        references user_table;
+
+    alter table module_admin_user 
+        add constraint FK8CE50E6E555F243E 
+        foreign key (admin) 
+        references user_table;
+
+    alter table module_admin_user 
+        add constraint FK8CE50E6E7080C8FC 
+        foreign key (module) 
+        references Module;
+
+    create sequence hibernate_sequence;

--- a/db/update-20.sql
+++ b/db/update-20.sql
@@ -1,0 +1,9 @@
+\set DB_SCHEMA_VERSION '\'20\''
+
+create table HerdDependency (
+    id int8 not null,
+    name varchar(255),
+    version varchar(255),
+    upload_id int8,
+    primary key (id)
+);


### PR DESCRIPTION
Add support for resolving module dependencies from Herd.  This is meant to address https://github.com/ceylon/ceylon-herd/issues/196.

This was tested with a module that supports both the jvm and javascript VM's.

A possible limitation to this implementation is that when uploading a new version of a module, a previously resolved depedency (ex ceylon.collection "1.1.0") must be once more resolved in the latest upload.